### PR TITLE
Merge Arrays Example

### DIFF
--- a/pulsar_devkit/simple_examples/HLSIPs/run_simple_algo_sum_arrays.tcl
+++ b/pulsar_devkit/simple_examples/HLSIPs/run_simple_algo_sum_arrays.tcl
@@ -1,0 +1,30 @@
+# open the project, don't forget to reset
+open_project -reset proj0
+
+set prefix "simple_algo_sum_arrays"
+set version "_fixed"
+set topFunc ${prefix}${version}_hw
+set_top ${topFunc}
+add_files src/simple_algo_sum_arrays.cpp
+add_files -tb simple_algo_sum_arrays_test.cpp -cflags "-DTOP_FUNC=${topFunc}"
+add_files -tb simple_algo_sum_arrays_ref.cpp
+
+# reset the solution
+open_solution -reset "solution1_${prefix}${version}"
+# part options:
+#	xcku9p-ffve900-2-i-EVAL
+#	xc7vx690tffg1927-2
+#	xcku5p-sfvb784-3-e
+#	xcku115-flvf1924-2-i
+#	xcvu9p-flga2104-2l-e
+set_part {xcvu9p-flga2104-2l-e}
+create_clock -period 3.125 -name default
+
+# do stuff
+csim_design
+csynth_design
+cosim_design -trace_level all
+export_design -format ip_catalog  -vendor "cern-cms"
+
+# exit Vivado HLS
+exit

--- a/pulsar_devkit/simple_examples/HLSIPs/simple_algo_sum_arrays_ref.cpp
+++ b/pulsar_devkit/simple_examples/HLSIPs/simple_algo_sum_arrays_ref.cpp
@@ -1,0 +1,13 @@
+#include "src/simple_algo_sum_arrays.h"
+
+void simple_algo_sum_arrays_ref(type_t in_ref[N_COLUMNS][N_ROWS], type_t out_ref[N_OUTPUTS]) {
+    for (int iRow = 0; iRow < N_ROWS; ++iRow) {
+        for (int iCol = 0; iCol < N_COLUMNS; ++iCol) {
+        	if (out_ref[iRow]+in_ref[iCol][iRow]> MAXBIN+1)
+        		out_ref[iRow] = MAXBIN;
+        	else
+	            out_ref[iRow] += in_ref[iCol][iRow];
+        }
+    }
+}
+

--- a/pulsar_devkit/simple_examples/HLSIPs/simple_algo_sum_arrays_test.cpp
+++ b/pulsar_devkit/simple_examples/HLSIPs/simple_algo_sum_arrays_test.cpp
@@ -1,0 +1,65 @@
+#include "src/simple_algo_sum_arrays.h"
+#include <cstdio>
+#include <iostream>
+#include <random>
+
+int main() {
+	
+    type_t   in_ref[N_COLUMNS][N_ROWS];
+    type_t   out_ref[N_OUTPUTS];
+    invec    in_hw[N_COLUMNS];
+    type_t   out_hw[N_OUTPUTS];
+  
+    std::default_random_engine generator;
+    std::uniform_int_distribution<int> distribution(1,35);
+
+    //Fill the inputs and reset the outputs
+    for (int iRow = 0; iRow < N_ROWS; ++iRow) {
+        for (int iCol = 0; iCol < N_COLUMNS; ++iCol) {    
+            //float value = (N_COLUMNS*iRow)+iCol;
+            int value = distribution(generator);
+            in_ref[iCol][iRow] = type_t(value);
+            in_hw[iCol].data[iRow] = type_t(value);
+        }
+        out_ref[iRow] = 0;
+        out_hw[iRow] = 0;
+    }
+
+    //Produce a coe file from the inputs
+    produce_coe_file(in_ref);
+
+    //Run the ref and hw codes
+    printf("Running the reference function ... ");
+    simple_algo_sum_arrays_ref(in_ref,out_ref);
+    printf("DONE\nRunning the hardware function ... ");
+    TOP_FUNC(in_hw,out_hw);
+    printf("DONE\n");
+
+    //Print the input and the output
+    int mismatch = 0;
+    for (int iCol = 0; iCol < N_COLUMNS; ++iCol) {
+        if(iCol==0) printf("%8s","INPUT");
+        printf("   C%2i",iCol);
+        if(iCol==N_COLUMNS-1) {
+            printf("%6s","REF");
+            printf("%6s","HW");
+            printf("%6s","Match");
+            printf("\n");
+        }
+    }
+    for (int iRow = 0; iRow < N_ROWS; ++iRow) {
+        for (int iCol = 0; iCol < N_COLUMNS; ++iCol) {
+            if (iCol==0) printf("  Row%3i",iRow);
+            printf("%6i",int(in_ref[iCol][iRow]));
+        }
+        printf("%6i",int(out_ref[iRow]));
+        printf("%6i",int(out_hw[iRow]));
+        printf("%6i",(out_ref[iRow]==out_hw[iRow])?1:0);
+        if(out_ref[iRow]!=out_hw[iRow]) mismatch++;
+        printf("\n");
+    }
+    printf("Matches: %i/%i (%0.1f%%)\n",int(N_OUTPUTS-mismatch),N_OUTPUTS,(float(N_OUTPUTS-mismatch)/N_OUTPUTS)*100.);
+
+    if(mismatch==0) return 0;
+    else return -1;
+}

--- a/pulsar_devkit/simple_examples/HLSIPs/src/simple_algo_sum_arrays.cpp
+++ b/pulsar_devkit/simple_examples/HLSIPs/src/simple_algo_sum_arrays.cpp
@@ -1,0 +1,41 @@
+#include "simple_algo_sum_arrays.h"
+#include <cmath>
+#include <cassert>
+#ifndef __SYNTHESIS__
+#include <cstdio>
+#endif
+
+void simple_algo_sum_arrays_hw(invec in_hw[N_COLUMNS], type_t out_hw[N_OUTPUTS]) {
+	#pragma HLS pipeline II=1
+	#pragma HLS ARRAY_PARTITION variable=in_hw complete
+	#pragma HLS ARRAY_PARTITION variable=in_hw->data complete
+	#pragma HLS ARRAY_PARTITION variable=out_hw complete
+
+	loopRow: for (int iRow = 0; iRow < N_ROWS; ++iRow) {
+		type_t sum = 0;
+        loopCol: for (int iCol = 0; iCol < N_COLUMNS; ++iCol) {
+        	sum += in_hw[iCol].data[iRow];
+        	sum = (sum > MAXBIN+1) ? type_t(MAXBIN) : sum;
+        }
+      	out_hw[iRow] = sum;
+    }
+}
+
+// This is the better version
+void simple_algo_sum_arrays_fixed_hw(invec in_hw[N_COLUMNS], type_t out_hw[N_OUTPUTS]) {
+	#pragma HLS pipeline II=1
+	#pragma HLS ARRAY_PARTITION variable=in_hw complete
+	#pragma HLS ARRAY_PARTITION variable=in_hw->data complete
+	#pragma HLS ARRAY_PARTITION variable=out_hw complete
+
+	loopRow: for (int iRow = 0; iRow < N_ROWS; ++iRow) {
+		tmp_t sum = 0;
+        loopCol: for (int iCol = 0; iCol < N_COLUMNS; ++iCol) {
+        	sum += in_hw[iCol].data[iRow];
+        }
+      	out_hw[iRow] = (type_t)sum;
+    }
+    loopMax: for (int iRow = 0; iRow < N_ROWS; ++iRow) {
+    	if (out_hw[iRow] > MAXBIN+1) out_hw[iRow] = (type_t)MAXBIN;
+    }
+}

--- a/pulsar_devkit/simple_examples/HLSIPs/src/simple_algo_sum_arrays.h
+++ b/pulsar_devkit/simple_examples/HLSIPs/src/simple_algo_sum_arrays.h
@@ -1,0 +1,58 @@
+#ifndef SIMPLE_ALGO_SUM_ARRAYS_H
+#define SIMPLE_ALGO_SUM_ARRAYS_H
+
+// Xilinx Libraries
+#include "ap_int.h"
+#include "ap_fixed.h"
+
+// STL Libraries
+#include <cstdio>
+#include <bitset>
+
+#define N_COLUMNS     27
+#define N_ROWS        24
+#define N_OUTPUTS     N_ROWS
+#define BITS_PER_WORD 11
+#define MAXBIN        511
+
+typedef ap_uint<BITS_PER_WORD>                                   type_t;
+typedef struct { type_t data[N_ROWS]; }                          invec;
+typedef ap_ufixed<BITS_PER_WORD+2,BITS_PER_WORD+2,AP_RND,AP_SAT> tmp_t; //+2 seems to lead to the best balance of timing and resources
+
+inline void produce_coe_file(type_t in_ref[N_COLUMNS][N_ROWS]) {
+	std::bitset<BITS_PER_WORD> bset_;
+
+	FILE *file_ = fopen("input.coe", "w");
+	fprintf(file_,"; Sample memory initialization file for Dual Port Block Memory,\n");
+	fprintf(file_,"; v3.0 or later.\n");
+	fprintf(file_,"; Board: Board_?\n");
+	fprintf(file_,"; tmux: 1\n");
+	fprintf(file_,";\n");
+	fprintf(file_,"; This .COE file specifies the contents for a block memory\n");
+	fprintf(file_,"; of depth=24, and width=2970. In this case, values are specified\n");
+	fprintf(file_,"; in binary format.\n");
+	fprintf(file_,"memory_initialization_radix=2;\n");
+	fprintf(file_,"memory_initialization_vector=\n");
+	
+	for (int iRow = 0; iRow < N_ROWS; ++iRow) {
+        for (int iCol = 0; iCol < N_COLUMNS; ++iCol) {
+        	bset_.reset();
+        	//printf("%.1f\n",float(in_ref[iCol][iRow]));
+	        for(int b=0; b<BITS_PER_WORD; b++) {
+    	    	bset_.set(b,in_ref[iCol][iRow][b]);
+    	       	//if(iRow==0 && iCol<2) {
+        	//	printf("%i",int(in_ref[iCol][iRow][b]));
+        	//	if(b==BITS_PER_WORD-1) printf("\n");
+        	//}
+    		}
+        	fprintf(file_, "%s", bset_.to_string().c_str());
+	    }
+    	fprintf(file_, (iRow==N_ROWS-1) ? ";\n" : ",\n");
+    }
+    fclose(file_);
+}
+void simple_algo_sum_arrays_ref(type_t in_ref[N_COLUMNS][N_ROWS], type_t out_ref[N_OUTPUTS]);
+void simple_algo_sum_arrays_hw(invec in_hw[N_COLUMNS], type_t out_hw[N_OUTPUTS]);
+void simple_algo_sum_arrays_fixed_hw(invec in_hw[N_COLUMNS], type_t out_hw[N_OUTPUTS]);
+
+#endif


### PR DESCRIPTION
Add a new example on how to merge multiple arrays together (sum the bins across the arrays) all while having a saturation requirement. The saturation requirement is fulfilled by using the ap_fixed type, which has built-in saturation protection.